### PR TITLE
Export library and include dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,6 @@ cmake_minimum_required(VERSION 3.2)
 
 set(ROOT_PROJECT_NAME ${PROJECT_NAME} CACHE STRING "root project name")
 
-set(PacBioBAM_build_docs    OFF CACHE INTERNAL "" FORCE)
-set(PacBioBAM_build_tests   OFF CACHE INTERNAL "" FORCE)
-set(PacBioBAM_build_tools   OFF CACHE INTERNAL "" FORCE)
-
 # Build type
 IF(NOT CMAKE_BUILD_TYPE)
     SET(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug Release Profile RelWithDebInfo" FORCE)

--- a/cmake/uny-dependencies.cmake
+++ b/cmake/uny-dependencies.cmake
@@ -1,6 +1,7 @@
 
 # External libraries
 
+# Get static libraries
 SET(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
 # pbcopper
@@ -32,14 +33,27 @@ if(NOT HTSLIB_INCLUDE_DIRS OR
 endif()
 
 # pbbam
-if (NOT pbbam)
+if (NOT PacBioBAM_INCLUDE_DIRS OR
+    NOT PacBioBAM_LIBRARIES)
+    set(PacBioBAM_build_docs    OFF CACHE INTERNAL "" FORCE)
+    set(PacBioBAM_build_tests   OFF CACHE INTERNAL "" FORCE)
+    set(PacBioBAM_build_tools   OFF CACHE INTERNAL "" FORCE)
     add_subdirectory(${UNY_ThirdPartyDir}/pbbam external/pbbam/build)
     if (TARGET htslib)
         add_dependencies(pbbam htslib)
     endif()
 endif()
 
-
 # cpp-optparse sources
-set(CPPOPTPARSE_CPP ${UNY_ThirdPartyDir}/cpp-optparse/OptionParser.cpp)
-set(CPPOPTPARSE_H   ${UNY_ThirdPartyDir}/cpp-optparse)
+if (NOT CPPOPTPARSE_CPP)
+    set(CPPOPTPARSE_CPP ${UNY_ThirdPartyDir}/cpp-optparse/OptionParser.cpp CACHE INTERNAL "" FORCE)
+endif()
+
+if (NOT CPPOPTPARSE_IncludeDir)
+    set(CPPOPTPARSE_IncludeDir ${UNY_ThirdPartyDir}/cpp-optparse CACHE INTERNAL "" FORCE)
+endif()
+
+# seqan headers
+if (NOT SEQAN_INCLUDE_DIRS)
+    set(SEQAN_INCLUDE_DIRS ${UNY_ThirdPartyDir}/seqan/include CACHE INTERNAL "" FORCE)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,15 +16,22 @@ add_library(unanimity STATIC
 )
 
 # includes
-target_include_directories(unanimity PUBLIC
+set(UNY_INCLUDE_DIRS
     ${UNY_IncludeDir}
     ${CMAKE_BINARY_DIR}/generated
     ${Boost_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIRS}
     ${HTSLIB_INCLUDE_DIRS}
-    ${UNY_ThirdPartyDir}/seqan/include
-    ${CPPOPTPARSE_H}
+    ${SEQAN_INCLUDE_DIRS}
+    ${CPPOPTPARSE_IncludeDir}
     ${PacBioBAM_INCLUDE_DIRS}
+    CACHE INTERNAL
+    "${PROJECT_NAME}: Include Directories"
+    FORCE
+)
+
+target_include_directories(unanimity PUBLIC
+    ${UNY_INCLUDE_DIRS}
 )
 
 if(APPLE)
@@ -34,11 +41,21 @@ elseif(UNIX)
     SET(POST_LINK -Wl,-no-whole-archive)
 endif()
 
-# because we can be a dependency, set this in the parent scope if so
-if(${ROOT_PROJECT_NAME} STREQUAL "UNANIMITY")
-    set(UNANIMITY_LIBRARIES ${PRE_LINK} unanimity ${POST_LINK} CACHE INTERNAL "" FORCE)
-else()
-    set(UNANIMITY_LIBRARIES ${PRE_LINK} unanimity ${POST_LINK} PARENT_SCOPE CACHE INTERNAL "" FORCE)
+set(UNY_LIBRARIES 
+    ${PRE_LINK} 
+    unanimity
+    ${POST_LINK}
+    ${ZLIB_LIBRARIES}
+    ${HTSLIB_LIBRARIES}
+    ${PacBioBAM_LIBRARIES}
+    CACHE INTERNAL "" FORCE)
+
+if (TARGET htslib)
+    add_dependencies(unanimity htslib)
+endif()
+
+if (TARGET pbbam)
+    add_dependencies(unanimity pbbam)
 endif()
 
 # add executables
@@ -50,16 +67,17 @@ if (UNY_build_bin)
     )
 
     target_link_libraries(ccs 
-        ${UNANIMITY_LIBRARIES}
-        ${PacBioBAM_LIBRARIES}
-        ${HTSLIB_LIBRARIES}
+        ${UNY_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
         ${CMAKE_DL_LIBS}
-        ${ZLIB_LIBRARIES}
     )
 
     if (TARGET htslib)
         add_dependencies(ccs htslib)
+    endif()
+
+    if (TARGET pbbam)
+        add_dependencies(ccs pbbam)
     endif()
 
     install(TARGETS ccs RUNTIME DESTINATION bin)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(_ConsensusCore2 MODULE
 )
 
 target_link_libraries(_ConsensusCore2
-    ${UNANIMITY_LIBRARIES}
+    ${UNY_LIBRARIES}
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,9 +43,7 @@ add_executable(test_unanimity EXCLUDE_FROM_ALL
 )
 
 target_link_libraries(test_unanimity
-    ${UNANIMITY_LIBRARIES}
-    ${PacBioBAM_LIBRARIES}
-    ${HTSLIB_LIBRARIES}
+    ${UNY_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${CMAKE_DL_LIBS}
     ${ZLIB_LIBRARIES}


### PR DESCRIPTION
- Export UNY_INCLUDE_DIRS that includes all necessary headers for unanimity and its dependencies
- Include pbbam and htslib in UNY_LIBRARIES
