### PR TITLE
Split libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UNY_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${UNY_DEBUG_FLAGS}")
 SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${UNY_LINKER_FLAGS}")
 
+if(APPLE)
+    set(PRE_LINK -force_load)
+elseif(UNIX)
+    SET(PRE_LINK -Wl,-whole-archive)
+    SET(POST_LINK -Wl,-no-whole-archive)
+endif()
+
 # Build library
 add_subdirectory(${UNY_SourceDir})
 

--- a/cmake/uny-dependencies.cmake
+++ b/cmake/uny-dependencies.cmake
@@ -19,41 +19,44 @@ if(NOT Boost_INCLUDE_DIRS)
     find_package(Boost REQUIRED)
 endif()
 
-# ZLIB
-if (NOT ZLIB_INCLUDE_DIRS OR NOT ZLIB_LIBRARIES)
-    find_package(ZLIB REQUIRED)
-endif()
-
-# htslib
-if(NOT HTSLIB_INCLUDE_DIRS OR
-   NOT HTSLIB_LIBRARIES)
-    find_package(htslib
-                 PATHS ${UNY_ThirdPartyDir}/htslib
-                 REQUIRED)
-endif()
-
-# pbbam
-if (NOT PacBioBAM_INCLUDE_DIRS OR
-    NOT PacBioBAM_LIBRARIES)
-    set(PacBioBAM_build_docs    OFF CACHE INTERNAL "" FORCE)
-    set(PacBioBAM_build_tests   OFF CACHE INTERNAL "" FORCE)
-    set(PacBioBAM_build_tools   OFF CACHE INTERNAL "" FORCE)
-    add_subdirectory(${UNY_ThirdPartyDir}/pbbam external/pbbam/build)
-    if (TARGET htslib)
-        add_dependencies(pbbam htslib)
+# only require if NOT called from pip install
+if (NOT PYTHON_SWIG)
+    # ZLIB
+    if (NOT ZLIB_INCLUDE_DIRS OR NOT ZLIB_LIBRARIES)
+        find_package(ZLIB REQUIRED)
     endif()
-endif()
 
-# cpp-optparse sources
-if (NOT CPPOPTPARSE_CPP)
-    set(CPPOPTPARSE_CPP ${UNY_ThirdPartyDir}/cpp-optparse/OptionParser.cpp CACHE INTERNAL "" FORCE)
-endif()
+    # htslib
+    if(NOT HTSLIB_INCLUDE_DIRS OR
+       NOT HTSLIB_LIBRARIES)
+        find_package(htslib
+                     PATHS ${UNY_ThirdPartyDir}/htslib
+                     REQUIRED)
+    endif()
 
-if (NOT CPPOPTPARSE_IncludeDir)
-    set(CPPOPTPARSE_IncludeDir ${UNY_ThirdPartyDir}/cpp-optparse CACHE INTERNAL "" FORCE)
-endif()
+    # pbbam
+    if (NOT PacBioBAM_INCLUDE_DIRS OR
+        NOT PacBioBAM_LIBRARIES)
+        set(PacBioBAM_build_docs    OFF CACHE INTERNAL "" FORCE)
+        set(PacBioBAM_build_tests   OFF CACHE INTERNAL "" FORCE)
+        set(PacBioBAM_build_tools   OFF CACHE INTERNAL "" FORCE)
+        add_subdirectory(${UNY_ThirdPartyDir}/pbbam external/pbbam/build)
+        if (TARGET htslib)
+            add_dependencies(pbbam htslib)
+        endif()
+    endif()
 
-# seqan headers
-if (NOT SEQAN_INCLUDE_DIRS)
-    set(SEQAN_INCLUDE_DIRS ${UNY_ThirdPartyDir}/seqan/include CACHE INTERNAL "" FORCE)
+    # cpp-optparse sources
+    if (NOT CPPOPTPARSE_CPP)
+        set(CPPOPTPARSE_CPP ${UNY_ThirdPartyDir}/cpp-optparse/OptionParser.cpp CACHE INTERNAL "" FORCE)
+    endif()
+
+    if (NOT CPPOPTPARSE_IncludeDir)
+        set(CPPOPTPARSE_IncludeDir ${UNY_ThirdPartyDir}/cpp-optparse CACHE INTERNAL "" FORCE)
+    endif()
+
+    # seqan headers
+    if (NOT SEQAN_INCLUDE_DIRS)
+        set(SEQAN_INCLUDE_DIRS ${UNY_ThirdPartyDir}/seqan/include CACHE INTERNAL "" FORCE)
+    endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,19 +1,14 @@
 # get all header files for IDE support
 file(GLOB_RECURSE UNY_HEADER "${UNY_IncludeDir}/*.h")
 file(GLOB_RECURSE UNY_HIDDEN_HEADER "*.h")
-# get all cpp files
-file(GLOB_RECURSE UNY_CPP "*.cpp")
-# exclude executable cpp fles
-file(GLOB_RECURSE UNY_MAIN_CPP "main/*.cpp")
-list(REMOVE_ITEM UNY_CPP ${UNY_MAIN_CPP})
-
-# add main library including everything
-add_library(unanimity STATIC
-    ${UNY_CPP}
-    ${UNY_HEADER}
-    ${UNY_HIDDEN_HEADER}
-    ${CPPOPTPARSE_CPP}
-)
+# get sources for src/align
+file(GLOB UNY_ALIGN_CPP  "align/*.cpp")
+# get sources for src/matrix
+file(GLOB UNY_MATRIX_CPP "matrix/*.cpp")
+# get sources for src/models
+file(GLOB UNY_MODELS_CPP "models/*.cpp")
+# get sources for src/poa
+file(GLOB UNY_POA_CPP    "poa/*.cpp")
 
 # includes
 set(UNY_INCLUDE_DIRS
@@ -30,55 +25,93 @@ set(UNY_INCLUDE_DIRS
     FORCE
 )
 
-target_include_directories(unanimity PUBLIC
+include_directories(
     ${UNY_INCLUDE_DIRS}
 )
 
-if(APPLE)
-    set(PRE_LINK -force_load)
-elseif(UNIX)
-    SET(PRE_LINK -Wl,-whole-archive)
-    SET(POST_LINK -Wl,-no-whole-archive)
-endif()
+# add subset of sources that only contains cc2
+add_library(cc2 STATIC
+    ${UNY_ALIGN_CPP}
+    ${UNY_MATRIX_CPP}
+    ${UNY_MODELS_CPP}
+    ${UNY_POA_CPP}
+    AbstractIntegrator.cpp
+    Coverage.cpp
+    Evaluator.cpp
+    EvaluatorImpl.cpp
+    ModelConfig.cpp
+    ModelFactory.cpp
+    ModelFormFactory.cpp
+    ModelSelection.cpp
+    MonoMolecularIntegrator.cpp
+    MultiMolecularIntegrator.cpp
+    Mutation.cpp
+    Polish.cpp
+    Read.cpp
+    Recursor.cpp
+    Sequence.cpp
+    Template.cpp
+)
 
-set(UNY_LIBRARIES 
-    ${PRE_LINK} 
-    unanimity
-    ${POST_LINK}
-    ${ZLIB_LIBRARIES}
-    ${HTSLIB_LIBRARIES}
-    ${PacBioBAM_LIBRARIES}
-    CACHE INTERNAL "" FORCE)
-
-if (TARGET htslib)
-    add_dependencies(unanimity htslib)
-endif()
-
-if (TARGET pbbam)
-    add_dependencies(unanimity pbbam)
-endif()
-
-# add executables
-if (UNY_build_bin)
-    add_executable(ccs ${UNY_SourceDir}/main/ccs.cpp)
-    
-    set_target_properties(ccs PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+# only build if NOT called from pip install
+if (NOT PYTHON_SWIG)
+    # add main library including everything
+    add_library(unanimity STATIC
+        ${UNY_HEADER}
+        ${UNY_HIDDEN_HEADER}
+        ${CPPOPTPARSE_CPP}
+        ChainSeeds.cpp
+        ChemistryMapping.cpp
+        ChemistryTriple.cpp
+        Consensus.cpp
+        Interval.cpp
+        ReadId.cpp
+        SparsePoa.cpp
+        SubreadResultCounter.cpp
+        Timer.cpp
+        Utility.cpp
     )
 
-    target_link_libraries(ccs 
-        ${UNY_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT}
-        ${CMAKE_DL_LIBS}
-    )
+    set(UNY_LIBRARIES 
+        ${PRE_LINK}
+        cc2
+        unanimity
+        ${POST_LINK}
+        ${ZLIB_LIBRARIES}
+        ${HTSLIB_LIBRARIES}
+        ${PacBioBAM_LIBRARIES}
+        CACHE INTERNAL "" FORCE)
 
     if (TARGET htslib)
-        add_dependencies(ccs htslib)
+        add_dependencies(unanimity htslib)
     endif()
 
     if (TARGET pbbam)
-        add_dependencies(ccs pbbam)
+        add_dependencies(unanimity pbbam)
     endif()
 
-    install(TARGETS ccs RUNTIME DESTINATION bin)
+    # add executables
+    if (UNY_build_bin)
+        add_executable(ccs ${UNY_SourceDir}/main/ccs.cpp)
+        
+        set_target_properties(ccs PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+
+        target_link_libraries(ccs 
+            ${UNY_LIBRARIES}
+            ${CMAKE_THREAD_LIBS_INIT}
+            ${CMAKE_DL_LIBS}
+        )
+
+        if (TARGET htslib)
+            add_dependencies(ccs htslib)
+        endif()
+
+        if (TARGET pbbam)
+            add_dependencies(ccs pbbam)
+        endif()
+
+        install(TARGETS ccs RUNTIME DESTINATION bin)
+    endif()
 endif()

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(SYSTEM
 # and the original ConsensusCore used it by default.
 # We could use python -c "print(sysconfig.get_config_var('CCSHARED'))",
 # but it's honestly unnecessary and requires providing PYTHON_EXECUTABLE
-target_compile_options(unanimity PUBLIC -fPIC)
+target_compile_options(cc2 PUBLIC -fPIC)
 add_compile_options(-fPIC)
 
 # ConsensusCore2_wrap.cxx
@@ -46,8 +46,14 @@ add_library(_ConsensusCore2 MODULE
     ConsensusCore2_wrap.cxx
 )
 
+set(CC2_LIBRARIES 
+    ${PRE_LINK}
+    cc2
+    ${POST_LINK}
+    CACHE INTERNAL "" FORCE)
+
 target_link_libraries(_ConsensusCore2
-    ${UNY_LIBRARIES}
+    ${CC2_LIBRARIES}
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(SYSTEM
     ${ZLIB_INCLUDE_DIRS}
     ${HTSLIB_INCLUDE_DIRS}
     ${UNY_ThirdPartyDir}/seqan/include
-    ${CPPOPTPARSE_H}
+    ${CPPOPTPARSE_IncludeDir}
     unit/
     ${PacBioBAM_INCLUDE_DIRS}
 )


### PR DESCRIPTION
- Split sources explicitly into two libraries, cc2 and unanimity.
- Minimize dependencies if called from pip install
